### PR TITLE
replace deprecated `actions/setup-ruby` with `ruby/setup-ruby` (fix #53)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1.1.3
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7.3
       - uses: actions/cache@v2.1.4
         with:
           path: vendor/bundle

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,9 +1,9 @@
 ---
-###########################
-###########################
-## Linter GitHub Actions ##
-###########################
-###########################
+#################################
+#################################
+## Super-Linter GitHub Actions ##
+#################################
+#################################
 name: Super-Linter
 
 #
@@ -39,6 +39,9 @@ jobs:
       ##########################
       - name: Checkout Code
         uses: actions/checkout@v2.3.4
+        with:
+          # linter requires full repository history
+          fetch-depth: 0
 
       ################################
       # Run Linter against code base #


### PR DESCRIPTION
`@actions/setup-ruby` is defunct; this would fix #53 and replace it